### PR TITLE
Validate forecast days parameter

### DIFF
--- a/Template.Application/Abstractions/IWeatherForecastService.cs
+++ b/Template.Application/Abstractions/IWeatherForecastService.cs
@@ -4,5 +4,13 @@ namespace Template.Application.Abstractions;
 
 public interface IWeatherForecastService
 {
+    /// <summary>
+    /// Returns a collection of randomly generated weather forecasts.
+    /// </summary>
+    /// <param name="days">The number of days to generate forecasts for.</param>
+    /// <returns>A sequence of <see cref="WeatherForecast"/> instances.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="days"/> is less than or equal to zero.
+    /// </exception>
     IEnumerable<WeatherForecast> GetForecast(int days);
 }

--- a/Template.Infrastructure/Services/RandomWeatherForecastService.cs
+++ b/Template.Infrastructure/Services/RandomWeatherForecastService.cs
@@ -12,6 +12,11 @@ public class RandomWeatherForecastService : IWeatherForecastService
 
     public IEnumerable<WeatherForecast> GetForecast(int days)
     {
+        if (days <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(days), "Days must be greater than zero.");
+        }
+
         return Enumerable.Range(1, days).Select(index =>
             new WeatherForecast(
                 DateOnly.FromDateTime(DateTime.Now.AddDays(index)),

--- a/Template.Tests/GlobalUsings.cs
+++ b/Template.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Template.Tests/RandomWeatherForecastServiceTests.cs
+++ b/Template.Tests/RandomWeatherForecastServiceTests.cs
@@ -1,0 +1,27 @@
+using Template.Infrastructure.Services;
+
+namespace Template.Tests;
+
+public class RandomWeatherForecastServiceTests
+{
+    [Fact]
+    public void GetForecast_WithPositiveDays_ReturnsExpectedCount()
+    {
+        var service = new RandomWeatherForecastService();
+
+        var result = service.GetForecast(3).ToArray();
+
+        Assert.Equal(3, result.Length);
+        Assert.Equal(DateOnly.FromDateTime(DateTime.Now.AddDays(1)), result[0].Date);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void GetForecast_WithNonPositiveDays_Throws(int days)
+    {
+        var service = new RandomWeatherForecastService();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => service.GetForecast(days));
+    }
+}

--- a/Template.Tests/Template.Tests.csproj
+++ b/Template.Tests/Template.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Template.Infrastructure\Template.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Template.sln
+++ b/Template.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -9,6 +9,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Template.Domain", "Template.Domain\Template.Domain.csproj", "{44AF54F4-78E1-4B73-BECF-8B23C96AB45A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Template.Infrastructure", "Template.Infrastructure\Template.Infrastructure.csproj", "{A6322BEF-3D3B-4D74-9C03-3C498D0774A1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Template.Tests", "Template.Tests\Template.Tests.csproj", "{F31D7E51-CAA0-40E6-A2A6-60B04145308D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,5 +37,9 @@ Global
 		{A6322BEF-3D3B-4D74-9C03-3C498D0774A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A6322BEF-3D3B-4D74-9C03-3C498D0774A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A6322BEF-3D3B-4D74-9C03-3C498D0774A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F31D7E51-CAA0-40E6-A2A6-60B04145308D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F31D7E51-CAA0-40E6-A2A6-60B04145308D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F31D7E51-CAA0-40E6-A2A6-60B04145308D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F31D7E51-CAA0-40E6-A2A6-60B04145308D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- validate `days` input before generating forecasts
- document `GetForecast` behavior
- add xunit test project covering valid and invalid input

## Testing
- `dotnet test --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68407142bfbc832a8a066e6579d94ae3